### PR TITLE
Add missing fields from spec + minor improvements

### DIFF
--- a/cmd/validate-sectxt/main.go
+++ b/cmd/validate-sectxt/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	printFields(f, "encryption")
 
-	printFields(f, "acknowledgement")
+	printFields(f, "acknowledgments")
 
 	if len(f.Errors()) > 0 {
 		os.Exit(3)

--- a/cmd/validate-sectxt/main.go
+++ b/cmd/validate-sectxt/main.go
@@ -44,11 +44,13 @@ func main() {
 	}
 	fmt.Println("")
 
-	printFields(f, "contact")
-
-	printFields(f, "encryption")
-
 	printFields(f, "acknowledgments")
+	printFields(f, "canonical")
+	printFields(f, "contact")
+	printFields(f, "encryption")
+	printFields(f, "hiring")
+	printFields(f, "policy")
+	printFields(f, "preferred-languages")
 
 	if len(f.Errors()) > 0 {
 		os.Exit(3)

--- a/field.go
+++ b/field.go
@@ -24,6 +24,16 @@ func newField(option, value string, comments []string) (Field, error) {
 
 	switch option {
 
+	case acknowledgmentsField:
+		if !validURI(value) {
+			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
+		}
+
+	case canonicalField:
+		if !validURI(value) {
+			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
+		}
+
 	case contactField:
 		if !validContact(value) {
 			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
@@ -34,10 +44,18 @@ func newField(option, value string, comments []string) (Field, error) {
 			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
 		}
 
-	case acknowledgmentsField:
+	case hiringField:
 		if !validURI(value) {
 			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
 		}
+
+	case policyField:
+		if !validURI(value) {
+			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
+		}
+
+	case preferredLanguagesField:
+		// TODO: Validate this properly
 
 	default:
 		return Field{}, fmt.Errorf("invalid option '%s'", option)

--- a/field.go
+++ b/field.go
@@ -34,7 +34,7 @@ func newField(option, value string, comments []string) (Field, error) {
 			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
 		}
 
-	case acknowledgementField:
+	case acknowledgmentsField:
 		if !validURI(value) {
 			return Field{}, fmt.Errorf("invalid value '%s' for option '%s'", value, option)
 		}

--- a/file.go
+++ b/file.go
@@ -39,6 +39,16 @@ func FromReader(r io.Reader) (*File, error) {
 	return parse(r)
 }
 
+// HasAcknowledgments returns true if there is at least one acknowledgments value
+func (f File) HasAcknowledgments() bool {
+	return len(f.Acknowledgments()) > 0
+}
+
+// Acknowledgments returns a slice of acknowledgments values from the File
+func (f File) Acknowledgments() []Field {
+	return f.Fields(acknowledgmentsField)
+}
+
 // Contact returns a slice of contact values from the File
 func (f File) Contact() []Field {
 	return f.Fields(contactField)
@@ -88,16 +98,6 @@ func (f File) HasEncryption() bool {
 // Encryption returns a slice of encryption URIs from the File
 func (f File) Encryption() []Field {
 	return f.Fields(encryptionField)
-}
-
-// HasAcknowledgement returns true if there is at least one acknowledgement value
-func (f File) HasAcknowledgement() bool {
-	return len(f.Acknowledgement()) > 0
-}
-
-// Acknowledgement returns a slice of acknowledgement values from the File
-func (f File) Acknowledgement() []Field {
-	return f.Fields(acknowledgementField)
 }
 
 // addComment adds a comment to the File

--- a/file.go
+++ b/file.go
@@ -90,6 +90,16 @@ func (f File) EmailContact() []Field {
 	return out
 }
 
+// HasCanonical returns true if there is at least one canonical value
+func (f File) HasCanonical() bool {
+	return len(f.Canonical()) > 0
+}
+
+// Canonical returns a slice of canonical values from the File
+func (f File) Canonical() []Field {
+	return f.Fields(canonicalField)
+}
+
 // HasEncryption returns true if there is at least one encryption value
 func (f File) HasEncryption() bool {
 	return len(f.Encryption()) > 0
@@ -98,6 +108,36 @@ func (f File) HasEncryption() bool {
 // Encryption returns a slice of encryption URIs from the File
 func (f File) Encryption() []Field {
 	return f.Fields(encryptionField)
+}
+
+// HasHiring returns true if there is at least one hiring value
+func (f File) HasHiring() bool {
+	return len(f.Hiring()) > 0
+}
+
+// Hiring returns a slice of hiring values from the File
+func (f File) Hiring() []Field {
+	return f.Fields(hiringField)
+}
+
+// HasPolicy returns true if there is at least one policy value
+func (f File) HasPolicy() bool {
+	return len(f.Policy()) > 0
+}
+
+// Policy returns a slice of policy values from the File
+func (f File) Policy() []Field {
+	return f.Fields(policyField)
+}
+
+// HasPreferredLanguages returns true if there is at least one preferredLanguages value
+func (f File) HasPreferredLanguages() bool {
+	return len(f.PreferredLanguages()) > 0
+}
+
+// PreferredLanguages returns a slice of preferredLanguages values from the File
+func (f File) PreferredLanguages() []Field {
+	return f.Fields(preferredLanguagesField)
 }
 
 // addComment adds a comment to the File

--- a/file.go
+++ b/file.go
@@ -17,6 +17,11 @@ func (f *File) addField(nf Field) {
 	f.fields = append(f.fields, nf)
 }
 
+// HasFields returns true if there is at least one field value
+func (f File) HasFields() bool {
+	return len(f.Fields("")) > 0
+}
+
 func (f File) Fields(filter string) []Field {
 	if filter == "" {
 		return f.fields
@@ -47,6 +52,11 @@ func (f File) HasAcknowledgments() bool {
 // Acknowledgments returns a slice of acknowledgments values from the File
 func (f File) Acknowledgments() []Field {
 	return f.Fields(acknowledgmentsField)
+}
+
+// HasContact returns true if there is at least one contact value
+func (f File) HasContact() bool {
+	return len(f.Contact()) > 0
 }
 
 // Contact returns a slice of contact values from the File

--- a/parse.go
+++ b/parse.go
@@ -8,9 +8,13 @@ import (
 )
 
 const (
-	contactField         = "contact"
-	encryptionField      = "encryption"
 	acknowledgmentsField    = "acknowledgments"
+	canonicalField          = "canonical"
+	contactField            = "contact"
+	encryptionField         = "encryption"
+	hiringField             = "hiring"
+	policyField             = "policy"
+	preferredLanguagesField = "preferred-languages"
 )
 
 func parse(r io.Reader) (*File, error) {

--- a/parse.go
+++ b/parse.go
@@ -10,7 +10,7 @@ import (
 const (
 	contactField         = "contact"
 	encryptionField      = "encryption"
-	acknowledgementField = "acknowledgement"
+	acknowledgmentsField    = "acknowledgments"
 )
 
 func parse(r io.Reader) (*File, error) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -37,8 +37,8 @@ func TestParse(t *testing.T) {
 		t.Errorf("want 1 encryption; have %d", len(f.Encryption()))
 	}
 
-	if len(f.Acknowledgement()) != 1 {
-		t.Logf("Acknowledgement: %#v", f.Acknowledgement())
-		t.Errorf("want 1 acknowledgement; have %d", len(f.Acknowledgement()))
+	if len(f.Acknowledgments()) != 1 {
+		t.Logf("Acknowledgments: %#v", f.Acknowledgments())
+		t.Errorf("want 1 acknowledgments; have %d", len(f.Acknowledgments()))
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -12,19 +12,13 @@ func TestParse(t *testing.T) {
 	}
 
 	f, err := FromReader(r)
-
 	if err == nil {
 		t.Logf("want non-nil error; have nil")
 	}
 
-	if len(f.Comments()) != 3 {
-		t.Logf("Comments: %#v", f.Comments())
-		t.Errorf("want 3 comments; have %d", len(f.Comments()))
-	}
-
-	if len(f.Errors()) != 3 {
-		t.Logf("Errors: %v", f.Errors())
-		t.Errorf("want 3 errors; have %d", len(f.Errors()))
+	if len(f.Acknowledgments()) != 1 {
+		t.Logf("Acknowledgments: %#v", f.Acknowledgments())
+		t.Errorf("want 1 acknowledgments; have %d", len(f.Acknowledgments()))
 	}
 
 	if len(f.Contact()) != 3 {
@@ -37,8 +31,28 @@ func TestParse(t *testing.T) {
 		t.Errorf("want 1 encryption; have %d", len(f.Encryption()))
 	}
 
-	if len(f.Acknowledgments()) != 1 {
-		t.Logf("Acknowledgments: %#v", f.Acknowledgments())
-		t.Errorf("want 1 acknowledgments; have %d", len(f.Acknowledgments()))
+	if len(f.Hiring()) != 1 {
+		t.Logf("Hiring: %#v", f.Hiring())
+		t.Errorf("want 1 hiring; have %d", len(f.Hiring()))
+	}
+
+	if len(f.Policy()) != 1 {
+		t.Logf("Policy: %#v", f.Policy())
+		t.Errorf("want 1 policy; have %d", len(f.Policy()))
+	}
+
+	if len(f.PreferredLanguages()) != 1 {
+		t.Logf("PreferredLanguages: %#v", f.PreferredLanguages())
+		t.Errorf("want 1 preferred-languages; have %d", len(f.PreferredLanguages()))
+	}
+
+	if len(f.Comments()) != 3 {
+		t.Logf("Comments: %#v", f.Comments())
+		t.Errorf("want 3 comments; have %d", len(f.Comments()))
+	}
+
+	if len(f.Errors()) != 3 {
+		t.Logf("Errors: %v", f.Errors())
+		t.Errorf("want 3 errors; have %d", len(f.Errors()))
 	}
 }

--- a/test/basic.txt
+++ b/test/basic.txt
@@ -9,5 +9,5 @@ Contact: Invalid
 Encryption: https://example.com/pgpkey.txt
 Encryption: Invalid
 
-Acknowledgement: https://example.com/hof
-Acknowledgement: Invalid
+Acknowledgements: https://example.com/hof
+Acknowledgements: Invalid

--- a/test/basic.txt
+++ b/test/basic.txt
@@ -1,6 +1,11 @@
 # This is an example file that contains 3 comments, 1 of each type of valid
 # contact and 1 invalid, 1 of each type of valid disclosure and 1 invalid,
 # 1 valid encryption and 1 invalid, 1 valid acknowledgement and 1 invalid
+Acknowledgments: https://example.com/hof
+Acknowledgments: Invalid
+
+Canonical: https://example.com/.well-known/security.txt
+
 Contact: mail@example.com
 Contact: https://example.com/security
 Contact: +44 5555 555 555
@@ -9,5 +14,8 @@ Contact: Invalid
 Encryption: https://example.com/pgpkey.txt
 Encryption: Invalid
 
-Acknowledgements: https://example.com/hof
-Acknowledgements: Invalid
+Hiring: https://example.com/jobs
+
+Policy: https://example.com/policy
+
+Preferred-Languages: en, ja


### PR DESCRIPTION
Fixes #1 

* Added missing fields: `canonical`, `hiring`, `policy`, `preferred-languages`
* Renamed fields:  `acknowledgement` to `acknowledgments` (to match spec)